### PR TITLE
[FIX] iOS Check Validity Card Delayed

### DIFF
--- a/ios/StripeCardInput.swift
+++ b/ios/StripeCardInput.swift
@@ -36,7 +36,7 @@ class StripeCardInput: UIView {
 }
 
 extension StripeCardInput: STPPaymentCardTextFieldDelegate {
-    func paymentCardTextFieldDidEndEditing(_ textField: STPPaymentCardTextField) {
+    func paymentCardTextFieldDidChange(_ textField: STPPaymentCardTextField) {
         self.onCardValid!(["isValid": textField.isValid])
     }
 }


### PR DESCRIPTION
This PR will change checking validity card every changes on the `STPPaymentCardTextField` using  `paymentCardTextFieldDidChange` delegate